### PR TITLE
Add install to setup, so we can easily get dependencies.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.venv*/
+*.egg-info*/
+__pycache__/

--- a/setup.py
+++ b/setup.py
@@ -19,4 +19,13 @@ setuptools.setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
+    install_requires=[
+        "numpy",
+        "scipy" ,
+        "pandas" ,
+        "mpmath" ,
+        "lmfit",
+        "matplotlib",
+        "seaborn"
+    ]
 )


### PR DESCRIPTION
When installing, it was required to manually install dependencies. This change adds the deps to the setup.py so user doesn't have to make an extra step to manually install.

Also added a .gitignore file to ignore any intermediate files created during setup.

Tested locally with `pip install -e .` and then `import PyEIS` from the REPL.